### PR TITLE
chore: set persist-credentials: false in actions/checkout

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
     - name: Run actionlint
       shell: bash
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1.16.1
         with:


### PR DESCRIPTION
## Summary

Set `persist-credentials: false` on every `actions/checkout` step to prevent the GitHub token from being written to a file under `$RUNNER_TEMP`, where it can be read (and base64-decoded) by any subsequent step.

The token-bearing config file is the default behavior of `actions/checkout`, and a compromised action or a script-injection bug elsewhere in the workflow can lift the token out of it. Turning credential persistence off removes that attack surface for the workflows that don't need to push back to the repo.

Reference: https://zenn.dev/kou_pg_0131/articles/gha-checkout-persist-credentials

## Test plan

- [x] `actionlint` passes
- [ ] Verify CI on this PR still runs to completion