### PR TITLE
ci: extend Dependabot cooldown to 7 days

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
       interval: "weekly"
       timezone: "Asia/Tokyo"
     cooldown:
-      default-days: 3
+      default-days: 7
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -19,4 +19,4 @@ updates:
       interval: "weekly"
       timezone: "Asia/Tokyo"
     cooldown:
-      default-days: 3
+      default-days: 7


### PR DESCRIPTION
## Summary

Bump `cooldown.default-days` in `.github/dependabot.yml` from `3` to `7` for every ecosystem block.

This addresses the `dependabot-cooldown` finding from `zizmor`, which flags anything below 7 days as "insufficient cooldown" — the rationale being that newly released package versions often have post-release issues (broken builds, regressions, malicious typosquats) discovered in the first few days, so giving them a week to settle before Dependabot auto-bumps reduces the chance of pulling in something compromised.

## Test plan

- [x] `actionlint` is unaffected (no workflow change)
- [ ] Next Dependabot cycle will respect the new 7-day cooldown