### PR TITLE
ci: pass tag and target via env in release rename step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,10 +47,13 @@ jobs:
         if: startsWith(matrix.os, 'macos')
       - name: Rename artifacts
         shell: bash
+        env:
+          REF_NAME: ${{ github.ref_name }}
+          TARGET: ${{ matrix.target }}
         run: |
-          mv target/${{ matrix.target }}/release/rpbcopyd{,-${{ github.ref_name }}-${{ matrix.target }}}
-          mv target/${{ matrix.target }}/release/rpbcopy{,-${{ github.ref_name }}-${{ matrix.target }}}
-          mv target/${{ matrix.target }}/release/rpbpaste{,-${{ github.ref_name }}-${{ matrix.target }}}
+          mv "target/${TARGET}/release/rpbcopyd" "target/${TARGET}/release/rpbcopyd-${REF_NAME}-${TARGET}"
+          mv "target/${TARGET}/release/rpbcopy" "target/${TARGET}/release/rpbcopy-${REF_NAME}-${TARGET}"
+          mv "target/${TARGET}/release/rpbpaste" "target/${TARGET}/release/rpbpaste-${REF_NAME}-${TARGET}"
       - name: Release
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
         with:


### PR DESCRIPTION
## Summary
zizmor's `template-injection` audit (High) flagged the `Rename artifacts` step in `release.yml` because `${{ github.ref_name }}` and `${{ matrix.target }}` were expanded directly inside the shell command, allowing a tag name crafted to include shell metacharacters to inject arbitrary commands.

Pass the values through `env:` and reference them as quoted shell variables so the shell never sees the raw expansion output. Drop the `{,-suffix}` brace expansion in favor of explicit `mv src dst` lines for clarity.

## Test plan
- [ ] Confirm zizmor no longer reports `template-injection` against `release.yml`.
- [ ] On the next tagged release, confirm artifact filenames are still `<binary>-<tag>-<target>` and are uploaded successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)