### PR TITLE
ci: opt out of Rust toolchain cache in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,11 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
         with:
           components: rustfmt
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+          # Skip Rust cache to avoid the cache-poisoning attack at release time:
+          # a poisoned cache written from a PR could otherwise be reused here
+          # and end up shipped as a GitHub Release artifact.
+          # See https://docs.zizmor.sh/audits/#cache-poisoning
+          cache: false
       - name: Build (Linux)
         run: |
           cargo install cross


### PR DESCRIPTION
## Summary
zizmor's `cache-poisoning` audit flagged both `actions-rust-lang/setup-rust-toolchain` (which auto-invokes `Swatinem/rust-cache` internally when `cache: true`, its default) and the redundant explicit `Swatinem/rust-cache` step in `release.yml`. A poisoned cache written from a PR build could otherwise be reused here and end up shipped as a GitHub Release artifact.

Set `cache: false` on `setup-rust-toolchain` with an inline comment explaining the rationale, mirroring the `bundler-cache: false` pattern in the Ruby skeleton's `release.yml`. The redundant `Swatinem/rust-cache` step is removed at the same time because `setup-rust-toolchain` already wraps it.

## Test plan
- [ ] Confirm zizmor no longer reports `cache-poisoning` against `release.yml`.
- [ ] On the next tagged release, confirm the build still completes (just without warm cache).

🤖 Generated with [Claude Code](https://claude.com/claude-code)