### PR TITLE
ci: replace softprops/action-gh-release with gh release commands

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,10 +59,16 @@ jobs:
           mv "target/${TARGET}/release/rpbcopy" "target/${TARGET}/release/rpbcopy-${REF_NAME}-${TARGET}"
           mv "target/${TARGET}/release/rpbpaste" "target/${TARGET}/release/rpbpaste-${REF_NAME}-${TARGET}"
       - name: Release
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
-        with:
-          name: rpbcopyd-${{ matrix.target }}
-          files: |
-            target/${{ matrix.target }}/release/rpbcopyd-${{ github.ref_name }}-${{ matrix.target }}
-            target/${{ matrix.target }}/release/rpbcopy-${{ github.ref_name }}-${{ matrix.target }}
-            target/${{ matrix.target }}/release/rpbpaste-${{ github.ref_name }}-${{ matrix.target }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REF_NAME: ${{ github.ref_name }}
+          TARGET: ${{ matrix.target }}
+        run: |
+          # Create the release if this matrix entry is the first to reach this step;
+          # otherwise reuse the existing release created by a sibling matrix entry.
+          gh release create "$REF_NAME" --title "$REF_NAME" --generate-notes 2>/dev/null || true
+          gh release upload "$REF_NAME" \
+            "target/${TARGET}/release/rpbcopyd-${REF_NAME}-${TARGET}" \
+            "target/${TARGET}/release/rpbcopy-${REF_NAME}-${TARGET}" \
+            "target/${TARGET}/release/rpbpaste-${REF_NAME}-${TARGET}" \
+            --clobber


### PR DESCRIPTION
## Summary
zizmor's `superfluous-actions` audit flagged `softprops/action-gh-release` in `release.yml` because the same functionality is already available through the `gh release` CLI bundled with GitHub-hosted runners.

Replace the action with two `gh release` invocations:
- `gh release create "$REF_NAME" --title "$REF_NAME" --generate-notes` — creates the release. Suppress the failure on the swallow path because sibling matrix entries may have already created it (matrix jobs race on the same tag).
- `gh release upload "$REF_NAME" ... --clobber` — attaches the per-target binaries, overwriting if a re-run uploads the same filename.

Pass `github.ref_name` and `matrix.target` via `env:` rather than expanding `${{ ... }}` inside the shell command (consistent with the earlier template-injection fix).

The previous workflow set `name: rpbcopyd-${{ matrix.target }}` on every parallel matrix entry, which caused the release title to race between targets. The replacement sets the title to the tag name once, which is consistent regardless of which matrix entry wins.

## Test plan
- [ ] Confirm zizmor no longer reports `superfluous-actions` against `release.yml`.
- [ ] On the next tagged release, confirm the release is created exactly once and all four target binaries (`x86_64-unknown-linux-musl`, `aarch64-unknown-linux-musl`, `x86_64-apple-darwin`, `aarch64-apple-darwin`) are uploaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)