### PR TITLE
chore: drop the ineffective RemoteTrigger permission rule

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,4 @@
 {
-  "permissions": {
-    "allow": ["RemoteTrigger"]
-  },
   "hooks": {
     "PreToolUse": [
       {


### PR DESCRIPTION
## Summary

Part of the same sweep as tk0miya/not_nilable#43, applied to this repository.

`RemoteTrigger` is not a real tool or permission rule name, so the entry in `permissions.allow` never matched anything and the self check-in tools kept prompting on every call. `setup-dev-workflow-hooks` tried replacing it with the actual MCP tool identifiers (`mcp__Claude_Code_Remote__send_later` / `delete_trigger`), verified those had no effect either, and removed the whole `permissions` block again.

`.claude/settings.json` now matches the setup-dev-workflow-hooks template byte for byte.

## Verification

- `.claude/settings.json` is identical to the skill template.
- `.claude/hooks/self-review.sh` is identical to the skill template (blob SHA `a292e9d`, mode 100755) and unchanged by this PR.
- `actionlint` passes, and every pinned action SHA — including `actions-rust-lang/setup-rust-toolchain` — was checked against the `tags` API. No workflow files are modified by this PR.

No test cases were added: the change removes a configuration entry that had no effect.

## Not applicable here

The rest of the sweep is Ruby-specific (`rbs:regenerate`, `rubocop.yml` ordering) and does not apply to this Rust project. `release.yml` already declares top-level `permissions`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)